### PR TITLE
packages correctly loaded for future_lapply

### DIFF
--- a/R/BatchtoolsFuture-class.R
+++ b/R/BatchtoolsFuture-class.R
@@ -45,7 +45,7 @@ BatchtoolsFuture <- function(expr = NULL, envir = parent.frame(),
                              substitute = TRUE, globals = TRUE,
                              label = "batchtools", cluster.functions = NULL,
                              resources = list(), workers = NULL,
-                             finalize = getOption("future.finalize", TRUE),
+                             finalize = getOption("future.finalize", TRUE),  packages = NULL, 
                              ...) {
   if (substitute) expr <- substitute(expr)
 
@@ -77,7 +77,7 @@ BatchtoolsFuture <- function(expr = NULL, envir = parent.frame(),
                    workers = workers, label = label, ...)
 
   future$globals <- gp$globals
-  future$packages <- gp$packages
+  future$packages <- c(packages, gp$packages)
 
   ## Create batchtools registry
   reg <- temp_registry(label = future$label)

--- a/tests/packages.R
+++ b/tests/packages.R
@@ -1,0 +1,21 @@
+library(batchtools)
+library(future)
+library(future.batchtools)
+library(data.table)
+
+make_data.table <- function(x){
+  return(data.table(a = x))
+}
+
+
+#define plan based on batchtools socket cluster
+reg <- makeRegistry(NA)
+reg$cluster.functions=makeClusterFunctionsSocket(2)
+plan(batchtools_custom,cluster.functions=reg$cluster.functions, workers=2)
+
+
+#this always works
+x %<-% make_data.table(1)
+
+#this used to break because it didn't load data.table on the workers
+xs <- future_lapply(1:10,make_data.table)


### PR DESCRIPTION
`future_lapply` behaves differently for `plan(batchtools_custom)` then for, e.g., `plan(session)` because the former doesn't use a packages argument. This small PR makes the behavior for `future.batchtools` plans more closely match the plans from the `future` package.

*BatchtoolsFuture-class.R now uses its packages argument.
*tests/packages.R is a MWE to verify this