### PR TITLE
robust to NULL osVersion

### DIFF
--- a/R/batchtools_lsf.R
+++ b/R/batchtools_lsf.R
@@ -52,7 +52,7 @@ BatchtoolsLsfFutureBackend <- function(...) {
 #'   data.frame(
 #'      hostname = Sys.info()[["nodename"]],
 #'            os = Sys.info()[["sysname"]],
-#'     osVersion = utils::osVersion,
+#'     osVersion = if (is.null(utils::osVersion)) NA else utils::osVersion,
 #'         cores = unname(parallelly::availableCores()),
 #'       modules = Sys.getenv("LOADEDMODULES")
 #'   )


### PR DESCRIPTION
https://stat.ethz.ch/R-manual/R-devel/library/utils/html/sessionInfo.html

I see this used in a few places -- checking in first before applying it elsewhere that this is something you find useful / the preferred approach for addressing it:

https://github.com/search?q=repo%3Afutureverse%2Ffuture.batchtools%20%2FosVersion%2F&type=code